### PR TITLE
refactor transfer inscription

### DIFF
--- a/scripts/test-filter.ts
+++ b/scripts/test-filter.ts
@@ -1,9 +1,4 @@
-import {
-  fetchOrdinals,
-  filterInscriptions,
-  fetchAndFilterInscriptions,
-} from "../src/ordinals-api";
-// import { fetchAndFilterInscriptions } from "../src/ord-api";
+import { fetchAndFilterInscriptions } from "../src/ordinals-api";
 
 const [indexStr] = process.argv.slice(2);
 
@@ -12,7 +7,11 @@ async function run() {
   const filtered = await fetchAndFilterInscriptions(index - 1);
   // const list = await fetchOrdinals(index - 1);
   // const filtered = await filterInscriptions(list);
-  console.log(filtered.inscriptions.map((i) => i._name));
+  const name = filtered.inscriptions.slice(0, 1).map((i) => i._name)[0];
+  if (name) {
+    console.log({ name, encoded: encodeURIComponent(name) });
+    console.log(encodeURIComponent(name));
+  }
   console.log("max ID:", filtered.maxId);
 }
 

--- a/src/ordinals-api/client/Ordinals.ts
+++ b/src/ordinals-api/client/Ordinals.ts
@@ -1,40 +1,41 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { BaseHttpRequest } from './core/BaseHttpRequest';
-import type { OpenAPIConfig } from './core/OpenAPI';
-import { AxiosHttpRequest } from './core/AxiosHttpRequest';
+import type { BaseHttpRequest } from "./core/BaseHttpRequest";
+import type { OpenAPIConfig } from "./core/OpenAPI";
+import { AxiosHttpRequest } from "./core/AxiosHttpRequest";
 
-import { InscriptionsService } from './services/InscriptionsService';
-import { SatoshisService } from './services/SatoshisService';
-import { StatusService } from './services/StatusService';
+import { InscriptionsService } from "./services/InscriptionsService";
+import { SatoshisService } from "./services/SatoshisService";
+import { StatusService } from "./services/StatusService";
 
 type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
 
 export class Ordinals {
+  public readonly inscriptions: InscriptionsService;
+  public readonly satoshis: SatoshisService;
+  public readonly status: StatusService;
 
-    public readonly inscriptions: InscriptionsService;
-    public readonly satoshis: SatoshisService;
-    public readonly status: StatusService;
+  public readonly request: BaseHttpRequest;
 
-    public readonly request: BaseHttpRequest;
+  constructor(
+    config?: Partial<OpenAPIConfig>,
+    HttpRequest: HttpRequestConstructor = AxiosHttpRequest
+  ) {
+    this.request = new HttpRequest({
+      BASE: config?.BASE ?? "https://api.hiro.so",
+      VERSION: config?.VERSION ?? "0.1.0",
+      WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
+      CREDENTIALS: config?.CREDENTIALS ?? "include",
+      TOKEN: config?.TOKEN,
+      USERNAME: config?.USERNAME,
+      PASSWORD: config?.PASSWORD,
+      HEADERS: config?.HEADERS,
+      ENCODE_PATH: config?.ENCODE_PATH,
+    });
 
-    constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
-        this.request = new HttpRequest({
-            BASE: config?.BASE ?? 'https://api.hiro.so',
-            VERSION: config?.VERSION ?? '0.0.1',
-            WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
-            CREDENTIALS: config?.CREDENTIALS ?? 'include',
-            TOKEN: config?.TOKEN,
-            USERNAME: config?.USERNAME,
-            PASSWORD: config?.PASSWORD,
-            HEADERS: config?.HEADERS,
-            ENCODE_PATH: config?.ENCODE_PATH,
-        });
-
-        this.inscriptions = new InscriptionsService(this.request);
-        this.satoshis = new SatoshisService(this.request);
-        this.status = new StatusService(this.request);
-    }
+    this.inscriptions = new InscriptionsService(this.request);
+    this.satoshis = new SatoshisService(this.request);
+    this.status = new StatusService(this.request);
+  }
 }
-

--- a/src/ordinals-api/client/core/OpenAPI.ts
+++ b/src/ordinals-api/client/core/OpenAPI.ts
@@ -1,31 +1,31 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiRequestOptions } from "./ApiRequestOptions";
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 type Headers = Record<string, string>;
 
 export type OpenAPIConfig = {
-    BASE: string;
-    VERSION: string;
-    WITH_CREDENTIALS: boolean;
-    CREDENTIALS: 'include' | 'omit' | 'same-origin';
-    TOKEN?: string | Resolver<string>;
-    USERNAME?: string | Resolver<string>;
-    PASSWORD?: string | Resolver<string>;
-    HEADERS?: Headers | Resolver<Headers>;
-    ENCODE_PATH?: (path: string) => string;
+  BASE: string;
+  VERSION: string;
+  WITH_CREDENTIALS: boolean;
+  CREDENTIALS: "include" | "omit" | "same-origin";
+  TOKEN?: string | Resolver<string>;
+  USERNAME?: string | Resolver<string>;
+  PASSWORD?: string | Resolver<string>;
+  HEADERS?: Headers | Resolver<Headers>;
+  ENCODE_PATH?: (path: string) => string;
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: 'https://api.hiro.so',
-    VERSION: '0.0.1',
-    WITH_CREDENTIALS: false,
-    CREDENTIALS: 'include',
-    TOKEN: undefined,
-    USERNAME: undefined,
-    PASSWORD: undefined,
-    HEADERS: undefined,
-    ENCODE_PATH: undefined,
+  BASE: "https://api.hiro.so",
+  VERSION: "0.1.0",
+  WITH_CREDENTIALS: false,
+  CREDENTIALS: "include",
+  TOKEN: undefined,
+  USERNAME: undefined,
+  PASSWORD: undefined,
+  HEADERS: undefined,
+  ENCODE_PATH: undefined,
 };

--- a/src/ordinals-api/client/services/InscriptionsService.ts
+++ b/src/ordinals-api/client/services/InscriptionsService.ts
@@ -13,7 +13,7 @@ export class InscriptionsService {
    * @returns any Default Response
    * @throws ApiError
    */
-  public getOrdinalsV1Inscriptions({
+  public getInscriptions({
     genesisBlock,
     fromGenesisBlockHeight,
     toGenesisBlockHeight,
@@ -129,7 +129,7 @@ export class InscriptionsService {
     results: Array<{
       id: string;
       number: number;
-      address: string;
+      address: string | null;
       genesis_address: string;
       genesis_block_height: number;
       genesis_block_hash: string;
@@ -139,8 +139,8 @@ export class InscriptionsService {
       tx_id: string;
       location: string;
       output: string;
-      value: string;
-      offset: string;
+      value: string | null;
+      offset: string | null;
       sat_ordinal: string;
       sat_rarity: string;
       sat_coinbase_height: number;
@@ -183,12 +183,80 @@ export class InscriptionsService {
   }
 
   /**
+   * Transfers per block
+   * Retrieves a list of inscription transfers that ocurred at a specific Bitcoin block
+   * @returns any Default Response
+   * @throws ApiError
+   */
+  public getTransfersPerBlock({
+    block,
+    offset,
+    limit,
+  }: {
+    /**
+     * Bitcoin block identifier (height or hash)
+     */
+    block: string;
+    /**
+     * Result offset
+     */
+    offset?: number;
+    /**
+     * Results per page
+     */
+    limit?: number;
+  }): CancelablePromise<{
+    limit: number;
+    offset: number;
+    total: number;
+    results: Array<{
+      id: string;
+      number: number;
+      from: {
+        block_height: number;
+        block_hash: string;
+        address: string | null;
+        tx_id: string;
+        location: string;
+        output: string;
+        value: string | null;
+        offset: string | null;
+        timestamp: number;
+      };
+      to: {
+        block_height: number;
+        block_hash: string;
+        address: string | null;
+        tx_id: string;
+        location: string;
+        output: string;
+        value: string | null;
+        offset: string | null;
+        timestamp: number;
+      };
+    }>;
+  }> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/ordinals/v1/inscriptions/transfers",
+      query: {
+        block: block,
+        offset: offset,
+        limit: limit,
+      },
+      errors: {
+        404: `Default Response`,
+      },
+    });
+  }
+
+  /**
    * Inscription
    * Retrieves a single inscription
    * @returns any Default Response
    * @throws ApiError
    */
-  public getOrdinalsV1Inscriptions1({
+  public getInscription({
     id,
   }: {
     /**
@@ -198,7 +266,7 @@ export class InscriptionsService {
   }): CancelablePromise<{
     id: string;
     number: number;
-    address: string;
+    address: string | null;
     genesis_address: string;
     genesis_block_height: number;
     genesis_block_hash: string;
@@ -208,8 +276,8 @@ export class InscriptionsService {
     tx_id: string;
     location: string;
     output: string;
-    value: string;
-    offset: string;
+    value: string | null;
+    offset: string | null;
     sat_ordinal: string;
     sat_rarity: string;
     sat_coinbase_height: number;
@@ -236,7 +304,7 @@ export class InscriptionsService {
    * @returns any Default Response
    * @throws ApiError
    */
-  public getOrdinalsV1InscriptionsContent({
+  public getInscriptionContent({
     id,
   }: {
     /**
@@ -249,6 +317,61 @@ export class InscriptionsService {
       url: "/ordinals/v1/inscriptions/{id}/content",
       path: {
         id: id,
+      },
+      errors: {
+        404: `Default Response`,
+      },
+    });
+  }
+
+  /**
+   * Inscription transfers
+   * Retrieves all transfers for a single inscription
+   * @returns any Default Response
+   * @throws ApiError
+   */
+  public getInscriptionTransfers({
+    id,
+    offset,
+    limit,
+  }: {
+    /**
+     * Inscription unique identifier (number or ID)
+     */
+    id: string | number;
+    /**
+     * Result offset
+     */
+    offset?: number;
+    /**
+     * Results per page
+     */
+    limit?: number;
+  }): CancelablePromise<{
+    limit: number;
+    offset: number;
+    total: number;
+    results: Array<{
+      block_height: number;
+      block_hash: string;
+      address: string | null;
+      tx_id: string;
+      location: string;
+      output: string;
+      value: string | null;
+      offset: string | null;
+      timestamp: number;
+    }>;
+  }> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/ordinals/v1/inscriptions/{id}/transfers",
+      path: {
+        id: id,
+      },
+      query: {
+        offset: offset,
+        limit: limit,
       },
       errors: {
         404: `Default Response`,

--- a/src/ordinals-api/client/services/SatoshisService.ts
+++ b/src/ordinals-api/client/services/SatoshisService.ts
@@ -1,49 +1,47 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { CancelablePromise } from '../core/CancelablePromise';
-import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+import type { CancelablePromise } from "../core/CancelablePromise";
+import type { BaseHttpRequest } from "../core/BaseHttpRequest";
 
 export class SatoshisService {
+  constructor(public readonly httpRequest: BaseHttpRequest) {}
 
-    constructor(public readonly httpRequest: BaseHttpRequest) {}
-
+  /**
+   * Satoshi Ordinal
+   * Retrieves ordinal information for a single satoshi
+   * @returns any Default Response
+   * @throws ApiError
+   */
+  public getSatoshi({
+    ordinal,
+  }: {
     /**
-     * Satoshi Ordinal
-     * Retrieves ordinal information for a single satoshi
-     * @returns any Default Response
-     * @throws ApiError
+     * Ordinal number that uniquely identifies a satoshi
      */
-    public getOrdinalsV1Sats({
-        ordinal,
-    }: {
-        /**
-         * Ordinal number that uniquely identifies a satoshi
-         */
-        ordinal: number,
-    }): CancelablePromise<{
-        coinbase_height: number;
-        cycle: number;
-        decimal: string;
-        degree: string;
-        inscription_id?: string;
-        epoch: number;
-        name: string;
-        offset: number;
-        percentile: string;
-        period: number;
-        rarity: ('common' | 'uncommon' | 'rare' | 'epic' | 'legendary' | 'mythic');
-    }> {
-        return this.httpRequest.request({
-            method: 'GET',
-            url: '/ordinals/v1/sats/{ordinal}',
-            path: {
-                'ordinal': ordinal,
-            },
-            errors: {
-                404: `Default Response`,
-            },
-        });
-    }
-
+    ordinal: number;
+  }): CancelablePromise<{
+    coinbase_height: number;
+    cycle: number;
+    decimal: string;
+    degree: string;
+    inscription_id?: string;
+    epoch: number;
+    name: string;
+    offset: number;
+    percentile: string;
+    period: number;
+    rarity: "common" | "uncommon" | "rare" | "epic" | "legendary" | "mythic";
+  }> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/ordinals/v1/sats/{ordinal}",
+      path: {
+        ordinal: ordinal,
+      },
+      errors: {
+        404: `Default Response`,
+      },
+    });
+  }
 }

--- a/src/ordinals-api/client/services/StatusService.ts
+++ b/src/ordinals-api/client/services/StatusService.ts
@@ -1,29 +1,27 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { CancelablePromise } from '../core/CancelablePromise';
-import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+import type { CancelablePromise } from "../core/CancelablePromise";
+import type { BaseHttpRequest } from "../core/BaseHttpRequest";
 
 export class StatusService {
+  constructor(public readonly httpRequest: BaseHttpRequest) {}
 
-    constructor(public readonly httpRequest: BaseHttpRequest) {}
-
-    /**
-     * API Status
-     * Displays the status of the API
-     * @returns any Default Response
-     * @throws ApiError
-     */
-    public getOrdinalsV1(): CancelablePromise<{
-        server_version: string;
-        status: string;
-        block_height?: number;
-        max_inscription_number?: number;
-    }> {
-        return this.httpRequest.request({
-            method: 'GET',
-            url: '/ordinals/v1/',
-        });
-    }
-
+  /**
+   * API Status
+   * Displays the status of the API
+   * @returns any Default Response
+   * @throws ApiError
+   */
+  public getApiStatus(): CancelablePromise<{
+    server_version: string;
+    status: string;
+    block_height?: number;
+    max_inscription_number?: number;
+  }> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/ordinals/v1/",
+    });
+  }
 }

--- a/src/ordinals-api/index.ts
+++ b/src/ordinals-api/index.ts
@@ -4,14 +4,19 @@ import { logger } from "../logger";
 import { WritableInscription } from "../sync";
 import { InscriptionContent, validateSnsInscription } from "../validator";
 import { Ordinals } from "./client";
-import { OpenAPIConfig } from "./client/core/OpenAPI";
 import sortBy from "lodash-es/sortBy";
 
 type InscriptionsService = Ordinals["inscriptions"];
 
 export type OrdinalsListResponse = Awaited<
-  ReturnType<InscriptionsService["getOrdinalsV1Inscriptions"]>
+  ReturnType<InscriptionsService["getInscriptions"]>
 >;
+
+export type OrdinalBlockTransferResponse = Awaited<
+  ReturnType<InscriptionsService["getTransfersPerBlock"]>
+>;
+
+export type OrdinalBlockTransfers = OrdinalBlockTransferResponse["results"];
 
 export type OrdinalsListItem = OrdinalsListResponse["results"][number];
 
@@ -22,6 +27,7 @@ export type InscriptionWithContent = OrdinalsListItem & {
 
 export const apiClient = new Ordinals();
 export const inscriptionsClient = apiClient.inscriptions;
+export const hiroStatusClient = apiClient.status;
 export const API_URL = new Ordinals().request.config.BASE;
 
 function getFilterConcurrency() {
@@ -39,9 +45,10 @@ const filterQueue = new PQueue({
 export async function fetchOrdinals(
   fromIndex: number
 ): Promise<OrdinalsListResponse> {
-  const list = await inscriptionsClient.getOrdinalsV1Inscriptions({
+  const list = await inscriptionsClient.getInscriptions({
     fromNumber: fromIndex + 1,
     limit: 60,
+    toNumber: fromIndex + 1000,
     // orderBy: "ordinal",
     order: "asc",
     mimeType: ["text/plain", "application/json"],
@@ -101,14 +108,14 @@ export function convertInscriptionToDb(
     inscriptionContentType: i["content_type"],
     inscriptionJSON: i.op as Prisma.RegistrationCreateInput["inscriptionJSON"],
     inscriptionIndex: i.number,
-    inscriptionOwner: i.address,
-    minter: i.address,
+    inscriptionOwner: i.address || "",
+    minter: i.address || "",
     sat: i.sat_ordinal,
     location: i.location,
     timestamp: BigInt(new Date(i.timestamp).getTime()),
     genesisHeight: i.genesis_block_height,
     genesisTransaction: i.genesis_tx_id,
-    outputValue: BigInt(i.value),
+    outputValue: BigInt(i.value ?? 0),
     name: {
       connectOrCreate: {
         where: { name },

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,7 +1,10 @@
 import { Prisma } from "@prisma/client";
-import { InscriptionContent } from "../validator";
+import { OWNERS_SYNC_ID } from "./owners";
 
 export const SYNC_VERSION = 7;
+if (Number(SYNC_VERSION) === OWNERS_SYNC_ID) {
+  throw new Error("SYNC_VERSION cannot be equal to OWNERS_SYNC_ID");
+}
 
 export type WritableInscription = {
   _name: string;

--- a/src/sync/owners.ts
+++ b/src/sync/owners.ts
@@ -2,9 +2,13 @@ import { PrismaClient, Registration } from "@prisma/client";
 import PQueue from "p-queue";
 import { AsyncTask, SimpleIntervalJob } from "toad-scheduler";
 import { logger } from "../logger";
-import { inscriptionsClient } from "../ordinals-api";
+import {
+  OrdinalBlockTransfers,
+  hiroStatusClient,
+  inscriptionsClient,
+} from "../ordinals-api";
 
-export const OWNERS_SYNC_ID = 2;
+export const OWNERS_SYNC_ID = 999999;
 
 const syncQueue = new PQueue({
   concurrency: 9,
@@ -21,83 +25,142 @@ export class OwnerSync {
     this.db = db;
   }
 
-  async syncFromIndex(registration?: {
-    inscriptionId: string;
-    inscriptionIndex: number;
-    inscriptionOwner: string;
-  }): Promise<true> {
-    let id = registration?.inscriptionId;
-    const isFirst = typeof id === "undefined";
-
-    if (isFirst) {
-      log.info("Starting owner sync");
-    } else {
-      log.info(`Continuing owner sync from ${registration!.inscriptionIndex}`);
-    }
-
-    const inscriptions = await this.db.registration.findMany({
+  async startSync() {
+    const maxSync = await this.db.syncs.findFirst({
       orderBy: {
-        inscriptionIndex: "asc",
+        inscriptionIndex: "desc",
       },
-      select: {
-        inscriptionId: true,
-        inscriptionIndex: true,
-        inscriptionOwner: true,
+      where: {
+        version: OWNERS_SYNC_ID,
       },
-      skip: isFirst ? 0 : 1,
-      cursor: isFirst
-        ? undefined
-        : {
-            inscriptionId: id,
-          },
-      take: 150,
     });
 
-    await Promise.all(inscriptions.map((i) => this.updateInscription(i)));
-
-    const len = inscriptions.length;
-
-    if (len === 0) {
-      log.info("Owner sync done!");
-      return true;
-    } else {
-      const last = inscriptions[len - 1];
-      return this.syncFromIndex(last);
+    let startHeight = maxSync?.inscriptionIndex;
+    if (typeof startHeight === "undefined") {
+      startHeight = 777735;
     }
+
+    startHeight = startHeight + 1;
+
+    const hiroStatus = await hiroStatusClient.getApiStatus();
+    const maxHeight = hiroStatus.block_height ?? startHeight + 1;
+
+    log.info(
+      {
+        height: startHeight,
+        maxHeight,
+      },
+      "Starting block sync"
+    );
+
+    if (startHeight === maxHeight) {
+      return true;
+    }
+
+    await this.syncBlock({
+      height: startHeight,
+    });
+
+    await this.db.syncs.create({
+      data: {
+        version: OWNERS_SYNC_ID,
+        inscriptionIndex: startHeight,
+        timestamp: new Date().getTime(),
+      },
+    });
+
+    return false;
   }
 
-  async updateInscription(i: {
-    inscriptionId: string;
-    inscriptionOwner: string;
-    inscriptionIndex: number;
-  }) {
-    const data = await syncQueue.add(() =>
-      inscriptionsClient.getOrdinalsV1Inscriptions1({
-        id: i.inscriptionId,
+  async syncBlock({
+    height,
+    offset = 0,
+  }: {
+    height: number;
+    offset?: number;
+  }): Promise<boolean> {
+    const limit = 60;
+    log.debug(
+      {
+        height,
+        offset,
+      },
+      "Syncing owners for block"
+    );
+    const transfers = await inscriptionsClient.getTransfersPerBlock({
+      limit,
+      block: String(height),
+      offset,
+    });
+
+    if (transfers.results.length === 0) {
+      return true;
+    }
+
+    const ids = transfers.results.map((t) => t.id);
+
+    const regs = await this.db.registration.findMany({
+      where: {
+        inscriptionId: {
+          in: ids,
+        },
+      },
+    });
+
+    log.debug(
+      {
+        height,
+        registrations: regs.length,
+      },
+      `Updating owners for ${regs.length} registrations`
+    );
+
+    await Promise.all(
+      regs.map(async (r) => {
+        await syncQueue.add(() => {
+          return this.updateWithTransfer(r, transfers.results);
+        });
       })
     );
-    if (!data) return;
 
-    const owner = data.address;
-    if (owner !== i.inscriptionOwner) {
-      log.info(
-        {
-          index: i.inscriptionIndex,
-          old: i.inscriptionOwner,
-          new: owner,
-        },
-        "New owner!"
-      );
-      await this.db.registration.update({
-        where: {
-          inscriptionId: i.inscriptionId,
-        },
-        data: {
-          inscriptionOwner: owner,
-          location: data.location,
-        },
-      });
+    if (offset + limit > transfers.total) {
+      return true;
     }
+    return this.syncBlock({
+      height,
+      offset: offset ?? 0 + limit,
+    });
+  }
+
+  async updateWithTransfer(
+    registration: Registration,
+    transfers: OrdinalBlockTransfers
+  ) {
+    const transfer = transfers.find((t) => t.id === registration.inscriptionId);
+    const newOwner = transfer?.to.address;
+    if (!transfer || !newOwner) return;
+    await this.db.registration.update({
+      where: {
+        inscriptionId: registration.inscriptionId,
+      },
+      data: {
+        inscriptionOwner: newOwner,
+        location: transfer.to.location,
+        outputValue: transfer.to.value
+          ? BigInt(transfer.to.value)
+          : registration.outputValue,
+      },
+    });
+  }
+}
+
+async function syncOwners(db: PrismaClient) {
+  const syncer = new OwnerSync(db);
+  const done = await syncer.startSync();
+  if (done) {
+    log.info("Owner sync done!");
+  } else {
+    await syncOwners(db);
   }
 }
 
@@ -110,8 +173,7 @@ export function makeOwnerSyncJob(db: PrismaClient) {
       if (running) return;
 
       running = true;
-      return new OwnerSync(db)
-        .syncFromIndex()
+      return syncOwners(db)
         .catch((e) => {
           console.error(e);
           logger.error({ error: e }, "Exception when syncing owner");
@@ -130,7 +192,7 @@ export function makeOwnerSyncJob(db: PrismaClient) {
     }
   );
 
-  return new SimpleIntervalJob({ hours: 1, runImmediately: true }, task, {
+  return new SimpleIntervalJob({ minutes: 10, runImmediately: true }, task, {
     preventOverrun: true,
   });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,3 +12,7 @@ export function getCodePoints(str: string) {
 
   return codePoints.join("");
 }
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
This PR aims to refactor the method of syncing owners of Sats names. It is based on an unfinished PR from another repository and seeks to complete the task.

Instead of fetching the current owner for each Sats inscription individually, the PR utilizes an API endpoint from the Hiro Ordinals API. This endpoint provides all Inscription transfers within a block, significantly improving performance when handling a large number of Sats names.

Further testing is required with full indexed dataset before it can be considered ready for production.